### PR TITLE
[] cleanup urls of social media pages

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -28,11 +28,11 @@
                 </a>
                     <ul class="right hide-on-med-and-down">
                         <li><a href="/faq">FAQ</a></li>
-                        <li><a href="/template/listPictures">
+                        <li><a href="/social/pictures">
                             <span class="hide-bellow-1250">Social media pictures</span>
                             <span class="hide-above-1250">Pictures</span> 
                         </a></li>
-                        <li><a href="/template/listPosts">
+                        <li><a href="/social/posts">
                             <span class="hide-bellow-1250">Social media posts</span>
                             <span class="hide-above-1250">Posts</span>  
                         </a></li>
@@ -43,8 +43,8 @@
                     </ul>
                     <ul id="nav-mobile" class="side-nav">
                         <li><a href="/faq">FAQ</a></li>
-                        <li><a href="/template/listPictures">Social media pictures</a></li>
-                       <li><a href="/template/listPosts">Social media posts</a></li>
+                        <li><a href="/social/pictures">Social media pictures</a></li>
+                        <li><a href="/social/posts">Social media posts</a></li>
                         <li><a href="/integrations">Integrations</a></li>
                         <li><a href="/doc/api/v1">API Documentation</a></li>
                         <li><a href="https://github.com/Pirate-Parties-International/PPI-party-info">Data on Github</a></li>

--- a/src/AppBundle/Controller/TemplateController.php
+++ b/src/AppBundle/Controller/TemplateController.php
@@ -8,7 +8,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 class TemplateController extends Controller
 {
     /**
-     * @Route("/template/listPictures")
+     * @Route("/social/pictures")
      */
     public function listPicturesAction()
     {
@@ -18,7 +18,7 @@ class TemplateController extends Controller
     }
 
     /**
-     * @Route("template/listPosts")
+     * @Route("social/posts")
      */
     public function listPostsAction()
     {

--- a/src/AppBundle/Controller/TemplateController.php
+++ b/src/AppBundle/Controller/TemplateController.php
@@ -8,7 +8,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 class TemplateController extends Controller
 {
     /**
-     * @Route("/social/pictures")
+     * @Route("/social/pictures", name="papi_social_pictures")
      */
     public function listPicturesAction()
     {
@@ -18,13 +18,26 @@ class TemplateController extends Controller
     }
 
     /**
-     * @Route("social/posts")
+     * @Route("social/posts", name="papi_social_posts")
      */
     public function listPostsAction()
     {
         return $this->render('AppBundle:Template:list_posts.html.twig', array(
             // ...
         ));
+    }
+
+    /**
+     * @Route("template/{id}")
+     */
+    public function redirectAction($id)
+    {
+        switch ($id) {
+            case 'listPictures':
+                return $this->redirectToRoute('papi_social_pictures');
+            case 'listPosts':
+                return $this->redirectToRoute('papi_social_posts');
+            }
     }
 
 }


### PR DESCRIPTION
Hey @GuruVII, @Putr, is there any reason we shouldn't pull this to the master branch?
Like, is there a specific reason why these pages have these urls?

If not, it's only a small change, but I think it would make the site look a little cleaner and more professional.

Thoughts?